### PR TITLE
Add FastAPI navigation MVP for phone client sync and offline profiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,4 @@ cython_debug/
 .idea/
 *.DS_Store
 tmp/
+tmp_*

--- a/PR_BODY.md
+++ b/PR_BODY.md
@@ -1,0 +1,38 @@
+﻿## Summary
+
+This PR adds a FastAPI navigation MVP on RaceStrategies so the native Android phone client (`solarcar_phone_app`, sibling repo) can create sessions, sync GPS telemetry, and download route profile bundles for offline target-speed lookup.
+
+Product model:
+
+- Backend/computer owns route/profile generation and future reoptimization.
+- Phone stores the full profile locally and maps GPS to target speed from cache when offline.
+- When online, phone calls `/sync` for advice and refreshed profiles; connection loss falls back to the last cached profile.
+
+**This repo (RaceStrategies):**
+
+- FastAPI app: health, routes, profile download, sessions, telemetry, and `/api/sessions/{id}/sync`.
+- Navigation layer: route mapping from KML/route data, advice builder, static/placeholder profile bundles.
+- Rolling sync **placeholder** (not real reoptimization): demo syncs bump `sync_count` and raise recommended/target speeds from the current position forward; live GPS syncs reuse the count without incrementing; `profile_current=false` so the phone always accepts MVP test updates.
+- In-memory session store, CORS for dev, readme + dependencies for running uvicorn.
+- Removed Capacitor/PWA prototype direction from this repo; phone UI lives only in `solarcar_phone_app`.
+- Minor kinematics helpers (`Speed.rps`, `Coordinate` repr) used by navigation/tests.
+
+**Phone client (separate repo — not in this commit):**
+
+- `C:\Code\solarcarnew\solarcar_phone_app` integrates with this API, caches profiles, offline lookup, and driver-facing status fields.
+
+## Not included yet
+
+- Real rolling reoptimization from position/velocity/SOC.
+- SOC/microcontroller fields in sync contract.
+- Durable session persistence.
+- Production race-day UI polish.
+
+## Test plan
+
+- [ ] `pytest tests/test_navigation_mvp.py` — route mapping, advice, profile bundles, session/telemetry flow, sync placeholder and rolling demo sync, GPS sync count behavior.
+- [ ] Run backend: `python -m uvicorn src.api.main:app --host 0.0.0.0 --port 8000`
+- [ ] In `solarcar_phone_app`, point API base URL at host (e.g. `http://10.0.2.2:8000` on BlueStacks/emulator).
+- [ ] Manual BlueStacks: create session, online sync, confirm advice and profile cache update.
+- [ ] Offline mode: disable network, confirm guidance from last cached profile.
+- [ ] Rolling sync demo: repeated demo syncs at same point show cumulative speed bump on current-and-future profile points.

--- a/PR_BODY.md
+++ b/PR_BODY.md
@@ -19,7 +19,7 @@ Product model:
 
 **Phone client (separate repo — not in this commit):**
 
-- `C:\Code\solarcarnew\solarcar_phone_app` integrates with this API, caches profiles, offline lookup, and driver-facing status fields.
+- [`solarcar_phone_app`](https://github.com/McMasterSolarCarProject/solarcar_phone_app) integrates with this API, caches profiles, offline lookup, and driver-facing status fields. See [phone app PR #1](https://github.com/McMasterSolarCarProject/solarcar_phone_app/pull/1) for the navigation MVP client work.
 
 ## Not included yet
 
@@ -28,11 +28,93 @@ Product model:
 - Durable session persistence.
 - Production race-day UI polish.
 
-## Test plan
+## Setup
 
-- [ ] `pytest tests/test_navigation_mvp.py` — route mapping, advice, profile bundles, session/telemetry flow, sync placeholder and rolling demo sync, GPS sync count behavior.
-- [ ] Run backend: `python -m uvicorn src.api.main:app --host 0.0.0.0 --port 8000`
-- [ ] In `solarcar_phone_app`, point API base URL at host (e.g. `http://10.0.2.2:8000` on BlueStacks/emulator).
-- [ ] Manual BlueStacks: create session, online sync, confirm advice and profile cache update.
-- [ ] Offline mode: disable network, confirm guidance from last cached profile.
-- [ ] Rolling sync demo: repeated demo syncs at same point show cumulative speed bump on current-and-future profile points.
+### Backend (this repo)
+
+1. Create and activate a Python venv, then install dependencies:
+
+   ```bash
+   python -m venv .venv
+   .venv\Scripts\activate          # Windows
+   pip install -r requirements.txt
+   ```
+
+2. Start the navigation API (keep this terminal open while testing):
+
+   ```bash
+   python -m uvicorn src.api.main:app --host 0.0.0.0 --port 8000
+   ```
+
+   Stop with **Ctrl+C** when running offline-fallback tests.
+
+3. **Windows firewall (LAN / physical phone):** allow inbound TCP **8000** on the host running uvicorn (Private network profile is usually enough). Find the host LAN IP with `ipconfig` (e.g. `192.168.1.42`).
+
+### Phone client (sibling repo)
+
+- Clone/build [`solarcar_phone_app`](https://github.com/McMasterSolarCarProject/solarcar_phone_app) per [PR #1](https://github.com/McMasterSolarCarProject/solarcar_phone_app/pull/1).
+
+**Physical phone on the same Wi‑Fi as the backend host** — rebuild with the host LAN IP:
+
+```powershell
+./gradlew assembleDebug -PraceStrategiesBaseUrl=http://<LAN-IP>:8000/
+```
+
+**Emulator / BlueStacks** — use the Android emulator loopback or the host LAN IP:
+
+- Android emulator: `http://10.0.2.2:8000/`
+- BlueStacks or emulator on same PC: `http://10.0.2.2:8000/` or `http://<LAN-IP>:8000/`
+
+## Testing
+
+### Automated
+
+```bash
+pytest tests/test_navigation_mvp.py
+```
+
+Covers route mapping, advice, profile bundles, session/telemetry flow, sync placeholder, rolling demo sync, and GPS sync-count behavior.
+
+### API smoke (backend running)
+
+```bash
+curl http://localhost:8000/api/health
+
+curl -X POST http://localhost:8000/api/sessions ^
+  -H "Content-Type: application/json" ^
+  -d "{\"route_name\": \"A. Independence to Topeka\"}"
+
+curl -X POST http://localhost:8000/api/sessions/<SESSION_ID>/sync ^
+  -H "Content-Type: application/json" ^
+  -d "{\"telemetry\": {\"lat\": 39.092185, \"lon\": -94.417077, \"speed_mps\": 10, \"source\": \"demo\"}}"
+```
+
+(On bash/macOS, use `\` line continuations and single-quoted JSON.)
+
+### Manual — phone app
+
+- [ ] **Start logging** — session created, telemetry/advice updates.
+- [ ] **Test Route Replay** — demo positions advance along the route.
+- [ ] **Next** — each tap triggers a demo sync; recommended speeds on current-and-future profile points bump (e.g. **32.19 → 32.20 → 32.21** km/h per sync with the MVP +0.01 km/h placeholder increment).
+- [ ] **Rolling sync** — repeated syncs at the same point accumulate the bump on future points.
+
+### Manual — offline fallback
+
+- [ ] With a cached profile on the phone, **stop the backend** (Ctrl+C in the uvicorn terminal).
+- [ ] Confirm guidance continues from the last cached profile (no crash; status reflects offline).
+
+### Manual — BlueStacks
+
+- [ ] Use BlueStacks **HD-Adb.exe** (not the standalone Android SDK `adb`) when sideloading or debugging.
+- [ ] Point base URL at `http://10.0.2.2:8000/` (or host LAN IP); run create session → sync → offline steps above.
+
+## Future: any-network access (Option B — not in this PR)
+
+Long-term plan: expose a home/race-day PC over the public internet so the phone works off-LAN (cellular, other Wi‑Fi):
+
+1. **DDNS** on the home router (stable hostname → public IP).
+2. **Port forward** (e.g. external 443 → host running RaceStrategies API).
+3. **HTTPS** termination (reverse proxy or uvicorn TLS) — do not ship plain HTTP over the internet.
+4. **In-app backend URL** in `solarcar_phone_app` (build-time or settings) pointing at `https://<your-hostname>/`.
+
+This PR and the current phone MVP target **same-LAN / emulator** only; Option B is a follow-up across infra + phone app configuration.

--- a/readme.md
+++ b/readme.md
@@ -17,6 +17,14 @@ run gui with:
 streamlit run src/streamlit_app.py
 ```
 
+run navigation backend with:
+```bash
+python -m uvicorn src.api.main:app --host 0.0.0.0 --port 8000
+```
+
+The native Android phone client lives in the sibling repo `solarcar_phone_app`.
+Point it at this backend URL (e.g. `http://10.0.2.2:8000` from the emulator).
+
 modify database setup in database.__main__.py
 modify sim setup in src.main.py
 

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,12 @@
 # How to Run:
 
-set up the python venv with requirments.txt
+Create a venv and install dependencies:
+
+```bash
+python -m venv .venv
+.venv\Scripts\activate          # Windows
+pip install -r requirements.txt
+```
 
 setup database by running:
 ```bash
@@ -22,8 +28,10 @@ run navigation backend with:
 python -m uvicorn src.api.main:app --host 0.0.0.0 --port 8000
 ```
 
-The native Android phone client lives in the sibling repo `solarcar_phone_app`.
-Point it at this backend URL (e.g. `http://10.0.2.2:8000` from the emulator).
+For a physical phone on the same Wi‑Fi, allow inbound TCP **8000** in Windows Firewall and rebuild the phone app with `-PraceStrategiesBaseUrl=http://<LAN-IP>:8000/`.
+
+The native Android phone client lives in the sibling repo [`solarcar_phone_app`](https://github.com/McMasterSolarCarProject/solarcar_phone_app).
+Point it at this backend URL (e.g. `http://10.0.2.2:8000/` from the emulator, or the host LAN IP on a physical device).
 
 modify database setup in database.__main__.py
 modify sim setup in src.main.py

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,16 @@
+# Render Blueprint — RaceStrategies navigation API
+# Docs: https://render.com/docs/blueprint-spec
+#
+# After merge, change `branch` to main (or your default deploy branch).
+services:
+  - type: web
+    name: racestrategies-api
+    runtime: python
+    plan: free
+    branch: feature/navigation-mvp-api
+    buildCommand: pip install -r requirements-api.txt
+    startCommand: uvicorn src.api.main:app --host 0.0.0.0 --port $PORT
+    healthCheckPath: /api/health
+    envVars:
+      - key: PYTHON_VERSION
+        value: "3.11.11"

--- a/requirements-api.txt
+++ b/requirements-api.txt
@@ -1,0 +1,4 @@
+# Minimal dependencies for the FastAPI navigation API (Render / production).
+# Desktop, GUI, and dashboard deps stay in requirements.txt.
+fastapi>=0.110.0
+uvicorn[standard]>=0.27.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,6 @@ streamlit-folium>=0.18.0
 plotly>=5.18.0
 numpy>=1.24.0
 scipy>=1.11.0
+fastapi
+uvicorn
+httpx

--- a/src/api/__init__.py
+++ b/src/api/__init__.py
@@ -1,0 +1,1 @@
+"""Phone-facing API for the navigation MVP."""

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+
+from src.api.schemas import (
+    AdviceResponse,
+    ClientProfileState,
+    CreateSessionRequest,
+    HealthResponse,
+    LookaheadResponse,
+    ProfileBundle,
+    RouteSummary,
+    RoutesResponse,
+    SessionResponse,
+    SyncRequest,
+    SyncResponse,
+    TelemetryRequest,
+)
+from src.api.session_store import NavigationSession, SessionStore, session_store
+from src.navigation.advice_builder import AdviceBuilder, DrivingAdvice
+from src.navigation.profile_builder import SYNC_PROFILE_VERSION, ProfileBundleBuilder
+from src.navigation.route_mapper import RouteNotFoundError, RouteRepository, get_default_repository
+
+
+def create_app(
+    repository: RouteRepository | None = None,
+    store: SessionStore | None = None,
+) -> FastAPI:
+    route_repository = repository or get_default_repository()
+    sessions = store or session_store
+    advice_builder = AdviceBuilder(route_repository)
+    profile_builder = ProfileBundleBuilder(route_repository)
+
+    app = FastAPI(title="Race Strategies Navigation MVP", version="0.1.0")
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+    @app.get("/api/health", response_model=HealthResponse)
+    def health() -> HealthResponse:
+        return HealthResponse(status="ok", routes_available=len(route_repository.list_routes()))
+
+    @app.get("/api/routes", response_model=RoutesResponse)
+    def routes() -> RoutesResponse:
+        return RoutesResponse(routes=[RouteSummary(name=name) for name in route_repository.list_routes()])
+
+    @app.get("/api/routes/{route_name}/profile", response_model=ProfileBundle)
+    def route_profile(route_name: str) -> ProfileBundle:
+        try:
+            return profile_builder.build(route_name)
+        except RouteNotFoundError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+    @app.post("/api/sessions", response_model=SessionResponse)
+    def create_session(request: CreateSessionRequest) -> SessionResponse:
+        route_name = request.route_name
+        try:
+            if route_name is None:
+                route_name = route_repository.default_route_name()
+            route_repository.load_route(route_name)
+        except RouteNotFoundError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+        session = sessions.create(route_name)
+        return _session_response(session)
+
+    @app.get("/api/sessions/{session_id}", response_model=SessionResponse)
+    def get_session(session_id: str) -> SessionResponse:
+        session = sessions.get(session_id)
+        if session is None:
+            raise HTTPException(status_code=404, detail="Session not found")
+        return _session_response(session)
+
+    @app.post("/api/sessions/{session_id}/telemetry", response_model=AdviceResponse)
+    def post_telemetry(session_id: str, telemetry: TelemetryRequest) -> AdviceResponse:
+        session = sessions.update_telemetry(session_id, telemetry)
+        if session is None:
+            raise HTTPException(status_code=404, detail="Session not found")
+
+        try:
+            match = route_repository.map_position(session.route_name, telemetry.lat, telemetry.lon)
+            advice = advice_builder.build(match, telemetry.speed_mps)
+        except RouteNotFoundError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+        return _advice_response(session.session_id, advice)
+
+    @app.post("/api/sessions/{session_id}/sync", response_model=SyncResponse)
+    def sync_session(session_id: str, request: SyncRequest) -> SyncResponse:
+        """/sync contract adapter for the navigation MVP.
+
+        This currently returns telemetry advice plus a backend-generated placeholder
+        profile when the client needs one. The future route-update/reoptimizer
+        should be called from this flow once that optimizer exists.
+        """
+        session = sessions.update_telemetry(session_id, request.telemetry)
+        if session is None:
+            raise HTTPException(status_code=404, detail="Session not found")
+
+        try:
+            match = route_repository.map_position(session.route_name, request.telemetry.lat, request.telemetry.lon)
+            advice = advice_builder.build(match, request.telemetry.speed_mps)
+            profile_current, profile = _build_rolling_sync_placeholder(
+                session,
+                session.route_name,
+                match.along_route_m,
+                request.telemetry,
+                request.client_profile,
+                profile_builder,
+            )
+        except RouteNotFoundError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+        return SyncResponse(
+            accepted=True,
+            server_time=datetime.now(timezone.utc),
+            profile_current=profile_current,
+            latest_profile_version=SYNC_PROFILE_VERSION,
+            sync_count=session.sync_count,
+            profile=profile,
+            advice=_advice_response(session.session_id, advice),
+        )
+
+    return app
+
+
+def _session_response(session: NavigationSession) -> SessionResponse:
+    return SessionResponse(
+        session_id=session.session_id,
+        route_name=session.route_name,
+        created_at=session.created_at,
+        last_telemetry_at=session.last_telemetry_at,
+    )
+
+
+def _build_rolling_sync_placeholder(
+    session,
+    route_name: str,
+    current_along_route_m: float,
+    telemetry: TelemetryRequest,
+    client_profile: ClientProfileState | None,
+    profile_builder: ProfileBundleBuilder,
+) -> tuple[bool, ProfileBundle | None]:
+    """Return a rolling /sync verification profile until route reoptimization exists.
+
+    Sync-path verification placeholder only — not a real optimizer. Demo /sync
+    requests increment the session sync_count and return an active profile where
+    the current point and all later points gain sync_count * 0.01 km/h over the
+    static base profile (along_route_m >= current telemetry position).
+    Live GPS syncs reuse the current sync_count without incrementing it.
+    profile_current stays false while the placeholder is active so the native phone
+    app always accepts the updated active profile during MVP testing.
+    """
+    del client_profile  # reserved for future optimizer idempotency checks
+    if telemetry.source == "demo":
+        session.sync_count += 1
+    profile = profile_builder.build_sync_placeholder(
+        route_name,
+        current_along_route_m,
+        session.sync_count,
+    )
+    return False, profile
+
+
+def _advice_response(session_id: str, advice: DrivingAdvice) -> AdviceResponse:
+    return AdviceResponse(
+        session_id=session_id,
+        route_name=advice.route_name,
+        segment_index=advice.segment_index,
+        along_route_m=advice.along_route_m,
+        cross_track_m=advice.cross_track_m,
+        off_route=advice.off_route,
+        distance_to_end_m=advice.distance_to_end_m,
+        recommended_speed_kmh=advice.recommended_speed_kmh,
+        speed_limit_kmh=advice.speed_limit_kmh,
+        grade_percent=advice.grade_percent,
+        elevation_m=advice.elevation_m,
+        target_speed_kmh=advice.target_speed_kmh,
+        torque_nm=advice.torque_nm,
+        power_w=advice.power_w,
+        action=advice.action,
+        warnings=advice.warnings,
+        lookahead=[
+            LookaheadResponse(
+                segment_index=item.segment_index,
+                distance_from_position_m=item.distance_from_position_m,
+                speed_limit_kmh=item.speed_limit_kmh,
+                grade_percent=item.grade_percent,
+                stop_type=item.stop_type,
+            )
+            for item in advice.lookahead
+        ],
+    )
+
+
+app = create_app()

--- a/src/api/schemas.py
+++ b/src/api/schemas.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class HealthResponse(BaseModel):
+    status: str
+    routes_available: int
+
+
+class RouteSummary(BaseModel):
+    name: str
+
+
+class RoutesResponse(BaseModel):
+    routes: list[RouteSummary]
+
+
+class CreateSessionRequest(BaseModel):
+    route_name: str | None = None
+
+
+class SessionResponse(BaseModel):
+    session_id: str
+    route_name: str
+    created_at: datetime
+    last_telemetry_at: datetime | None = None
+
+
+class TelemetryRequest(BaseModel):
+    lat: float = Field(..., ge=-90, le=90)
+    lon: float = Field(..., ge=-180, le=180)
+    speed_mps: float | None = Field(default=None, ge=0)
+    heading_deg: float | None = Field(default=None, ge=0, le=360)
+    timestamp: datetime | None = None
+    source: Literal["gps", "manual", "demo"] = "gps"
+
+
+class ClientProfileState(BaseModel):
+    route_name: str | None = None
+    profile_version: int | None = Field(default=None, ge=0)
+    profile_hash: str | None = None
+
+
+class ProfilePoint(BaseModel):
+    index: int
+    distance_m: float
+    along_route_m: float
+    lat: float
+    lon: float
+    elevation_m: float
+    recommended_speed_kmh: float
+    speed_limit_kmh: float | None = None
+    target_speed_kmh: float | None = None
+    torque_nm: float | None = None
+    power_w: float | None = None
+    grade_percent: float
+    stop_type: str | None = None
+
+
+class ProfileBundle(BaseModel):
+    route_name: str
+    profile_version: int
+    profile_hash: str
+    generated_at: datetime
+    total_distance_m: float
+    points: list[ProfilePoint]
+
+
+class SyncRequest(BaseModel):
+    telemetry: TelemetryRequest
+    client_profile: ClientProfileState | None = None
+
+
+class LookaheadResponse(BaseModel):
+    segment_index: int
+    distance_from_position_m: float
+    speed_limit_kmh: float | None = None
+    grade_percent: float
+    stop_type: str | None = None
+
+
+class AdviceResponse(BaseModel):
+    session_id: str
+    route_name: str
+    segment_index: int
+    along_route_m: float
+    cross_track_m: float
+    off_route: bool
+    distance_to_end_m: float
+    recommended_speed_kmh: float
+    speed_limit_kmh: float | None = None
+    grade_percent: float
+    elevation_m: float
+    target_speed_kmh: float | None = None
+    torque_nm: float | None = None
+    power_w: float | None = None
+    action: str
+    warnings: list[str]
+    lookahead: list[LookaheadResponse]
+
+
+class SyncResponse(BaseModel):
+    accepted: bool
+    server_time: datetime
+    profile_current: bool
+    latest_profile_version: int
+    sync_count: int = 0
+    profile: ProfileBundle | None = None
+    advice: AdviceResponse | None = None

--- a/src/api/session_store.py
+++ b/src/api/session_store.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from uuid import uuid4
+
+from .schemas import TelemetryRequest
+
+
+@dataclass
+class NavigationSession:
+    session_id: str
+    route_name: str
+    created_at: datetime
+    last_telemetry_at: datetime | None = None
+    last_telemetry: TelemetryRequest | None = None
+    sync_count: int = 0
+
+
+class SessionStore:
+    def __init__(self) -> None:
+        self._sessions: dict[str, NavigationSession] = {}
+
+    def create(self, route_name: str) -> NavigationSession:
+        session = NavigationSession(
+            session_id=str(uuid4()),
+            route_name=route_name,
+            created_at=datetime.now(timezone.utc),
+        )
+        self._sessions[session.session_id] = session
+        return session
+
+    def get(self, session_id: str) -> NavigationSession | None:
+        return self._sessions.get(session_id)
+
+    def update_telemetry(self, session_id: str, telemetry: TelemetryRequest) -> NavigationSession | None:
+        session = self.get(session_id)
+        if session is None:
+            return None
+        session.last_telemetry = telemetry
+        session.last_telemetry_at = telemetry.timestamp or datetime.now(timezone.utc)
+        return session
+
+
+session_store = SessionStore()

--- a/src/engine/kinematics.py
+++ b/src/engine/kinematics.py
@@ -72,6 +72,12 @@ class Coordinate:  # Should Be Calculated in Meters
     lon: float
     elevation: float = 0
 
+    def __str__(self):
+        return f"Lat: {self.lat}, Lon: {self.lon}, Elevation: {self.elevation}"
+
+    def __repr__(self):
+        return f"Lat: {self.lat}, Lon: {self.lon}, Elevation: {self.elevation}"
+
 NULL_COORDINATE = Coordinate(0,0,0)
 
 class Displacement(Vec):  # East-North-Up
@@ -149,6 +155,9 @@ class Speed:
 
     def rpm(self, radius: float = wheel_radius):
         return self.mps * 60 / (2 * math.pi * radius)
+
+    def rps(self, radius: float = wheel_radius):
+        return self.mps / (2 * math.pi * radius)
 
     def angular_velocity(self, radius: float = wheel_radius) -> float:
         # angular speed in radians per second

--- a/src/navigation/__init__.py
+++ b/src/navigation/__init__.py
@@ -1,0 +1,1 @@
+"""Navigation helpers for mapping GPS positions onto race routes."""

--- a/src/navigation/advice_builder.py
+++ b/src/navigation/advice_builder.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .route_mapper import RouteMatch, RouteRepository
+from .speed_utils import recommended_speed
+
+
+@dataclass(frozen=True)
+class LookaheadItem:
+    segment_index: int
+    distance_from_position_m: float
+    speed_limit_kmh: float | None
+    grade_percent: float
+    stop_type: str | None
+
+
+@dataclass(frozen=True)
+class DrivingAdvice:
+    route_name: str
+    segment_index: int
+    along_route_m: float
+    cross_track_m: float
+    off_route: bool
+    distance_to_end_m: float
+    recommended_speed_kmh: float
+    speed_limit_kmh: float | None
+    grade_percent: float
+    elevation_m: float
+    target_speed_kmh: float | None
+    torque_nm: float | None
+    power_w: float | None
+    action: str
+    warnings: list[str]
+    lookahead: list[LookaheadItem]
+
+
+class AdviceBuilder:
+    """Interim adapter from route-position matches to static driving advice.
+
+    This is not route-update or speed-plan optimization. It exposes the current
+    API contract by packaging route data, simple speed bounds, and nearby route
+    features until the real optimizer/reoptimizer is added.
+    """
+
+    def __init__(self, repository: RouteRepository, lookahead_distance_m: float = 1_000.0) -> None:
+        self.repository = repository
+        self.lookahead_distance_m = lookahead_distance_m
+
+    def build(self, match: RouteMatch, current_speed_mps: float | None = None) -> DrivingAdvice:
+        segment = match.segment
+        speed_limit_kmh = segment.speed_limit_kmh
+        target_speed_kmh = segment.target_speed_kmh
+        recommended_speed_kmh = recommended_speed(speed_limit_kmh, target_speed_kmh)
+        current_speed_kmh = current_speed_mps * 3.6 if current_speed_mps is not None else None
+
+        warnings: list[str] = []
+        if match.off_route:
+            warnings.append(f"Off route by {match.cross_track_m:.0f} m")
+
+        lookahead = self._lookahead(match)
+        stop_ahead = next((item for item in lookahead if item.stop_type), None)
+        if stop_ahead is not None:
+            warnings.append(f"Stop/checkpoint ahead in {stop_ahead.distance_from_position_m:.0f} m")
+
+        lower_limit_ahead = next(
+            (
+                item
+                for item in lookahead
+                if item.speed_limit_kmh is not None
+                and speed_limit_kmh is not None
+                and item.speed_limit_kmh < speed_limit_kmh - 1
+            ),
+            None,
+        )
+        if lower_limit_ahead is not None:
+            warnings.append(
+                f"Speed limit drops to {lower_limit_ahead.speed_limit_kmh:.0f} km/h in "
+                f"{lower_limit_ahead.distance_from_position_m:.0f} m"
+            )
+
+        action = self._action(current_speed_kmh, recommended_speed_kmh, match.off_route)
+        return DrivingAdvice(
+            route_name=match.route_name,
+            segment_index=match.segment_index,
+            along_route_m=match.along_route_m,
+            cross_track_m=match.cross_track_m,
+            off_route=match.off_route,
+            distance_to_end_m=match.distance_to_end_m,
+            recommended_speed_kmh=recommended_speed_kmh,
+            speed_limit_kmh=speed_limit_kmh,
+            grade_percent=segment.grade_percent,
+            elevation_m=segment.start.elevation_m,
+            target_speed_kmh=target_speed_kmh,
+            torque_nm=segment.start.torque_nm,
+            power_w=segment.start.power_w,
+            action=action,
+            warnings=warnings,
+            lookahead=lookahead,
+        )
+
+    def _action(self, current_speed_kmh: float | None, recommended_speed_kmh: float, off_route: bool) -> str:
+        if off_route:
+            return "return_to_route"
+        if current_speed_kmh is None:
+            return "hold"
+        if current_speed_kmh > recommended_speed_kmh + 3:
+            return "slow_down"
+        if current_speed_kmh < recommended_speed_kmh - 5:
+            return "speed_up"
+        return "hold"
+
+    def _lookahead(self, match: RouteMatch) -> list[LookaheadItem]:
+        route = self.repository.load_route(match.route_name)
+        items: list[LookaheadItem] = []
+        for segment in route.segments[match.segment_index :]:
+            distance_from_position_m = max(segment.start.distance_m - match.along_route_m, 0.0)
+            if distance_from_position_m > self.lookahead_distance_m:
+                break
+            items.append(
+                LookaheadItem(
+                    segment_index=segment.index,
+                    distance_from_position_m=distance_from_position_m,
+                    speed_limit_kmh=segment.speed_limit_kmh,
+                    grade_percent=segment.grade_percent,
+                    stop_type=segment.start.stop_type,
+                )
+            )
+        return items[:10]

--- a/src/navigation/profile_builder.py
+++ b/src/navigation/profile_builder.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+
+from src.api.schemas import ProfileBundle, ProfilePoint
+
+from .route_mapper import Route, RouteRepository
+from .speed_utils import recommended_speed
+
+
+PROFILE_VERSION = 1
+SYNC_PROFILE_VERSION = 2
+SYNC_SPEED_INCREMENT_KMH = 0.01
+SYNC_ALONG_ROUTE_EPSILON_M = 1e-3
+PROFILE_GENERATED_AT = datetime(1970, 1, 1, tzinfo=timezone.utc)
+
+
+class ProfileBundleBuilder:
+    """Builds a static route-derived profile bundle for the MVP contract.
+
+    This adapter serializes the loaded route points into the phone sync shape.
+    It does not compute an optimized profile or reoptimize around telemetry;
+    that behavior is future route-update work.
+    """
+
+    def __init__(self, repository: RouteRepository, profile_version: int = PROFILE_VERSION) -> None:
+        self.repository = repository
+        self.profile_version = profile_version
+
+    def build(self, route_name: str) -> ProfileBundle:
+        route = self.repository.load_route(route_name)
+        points = [_profile_point(route, index) for index, _ in enumerate(route.points)]
+        return ProfileBundle(
+            route_name=route.name,
+            profile_version=self.profile_version,
+            profile_hash=_profile_hash(route.name, self.profile_version, 0, points),
+            generated_at=PROFILE_GENERATED_AT,
+            total_distance_m=route.total_distance_m,
+            points=points,
+        )
+
+    def build_sync_placeholder(
+        self,
+        route_name: str,
+        current_along_route_m: float,
+        sync_count: int,
+    ) -> ProfileBundle:
+        """Build the /sync verification profile until real optimization exists.
+
+        Sync-path verification placeholder only — not a real optimizer. Each sync
+        adds sync_count * SYNC_SPEED_INCREMENT_KMH to the current profile point
+        and all later points (along_route_m >= current telemetry position).
+        Recommended speed is always
+        incremented for visibility; target speed is incremented only when the route
+        already has a target. Speed limit is unchanged. profile_hash changes every
+        sync so the phone can detect and cache the rolling active profile.
+        """
+        base_profile = self.build(route_name)
+        speed_increment_kmh = sync_count * SYNC_SPEED_INCREMENT_KMH
+        points = [
+            _sync_placeholder_point(point, current_along_route_m, speed_increment_kmh)
+            for point in base_profile.points
+        ]
+        return ProfileBundle(
+            route_name=base_profile.route_name,
+            profile_version=SYNC_PROFILE_VERSION,
+            profile_hash=_profile_hash(base_profile.route_name, SYNC_PROFILE_VERSION, sync_count, points),
+            generated_at=PROFILE_GENERATED_AT,
+            total_distance_m=base_profile.total_distance_m,
+            points=points,
+        )
+
+
+def _profile_point(route: Route, index: int) -> ProfilePoint:
+    point = route.points[index]
+    segment = route.segments[index] if index < len(route.segments) else None
+    speed_limit_kmh = segment.speed_limit_kmh if segment is not None else point.speed_limit_kmh
+    target_speed_kmh = segment.target_speed_kmh if segment is not None else point.target_speed_kmh
+
+    return ProfilePoint(
+        index=index,
+        distance_m=point.distance_m,
+        along_route_m=point.distance_m,
+        lat=point.lat,
+        lon=point.lon,
+        elevation_m=point.elevation_m,
+        recommended_speed_kmh=recommended_speed(speed_limit_kmh, target_speed_kmh),
+        speed_limit_kmh=speed_limit_kmh,
+        target_speed_kmh=target_speed_kmh,
+        torque_nm=point.torque_nm,
+        power_w=point.power_w,
+        grade_percent=segment.grade_percent if segment is not None else 0.0,
+        stop_type=point.stop_type,
+    )
+
+
+def _sync_placeholder_point(
+    point: ProfilePoint,
+    current_along_route_m: float,
+    speed_increment_kmh: float,
+) -> ProfilePoint:
+    if point.along_route_m + SYNC_ALONG_ROUTE_EPSILON_M < current_along_route_m or speed_increment_kmh <= 0:
+        return point
+
+    return point.model_copy(
+        update={
+            "recommended_speed_kmh": point.recommended_speed_kmh + speed_increment_kmh,
+            "target_speed_kmh": (
+                point.target_speed_kmh + speed_increment_kmh
+                if point.target_speed_kmh is not None
+                else None
+            ),
+        }
+    )
+
+
+def _profile_hash(
+    route_name: str,
+    profile_version: int,
+    sync_count: int,
+    points: list[ProfilePoint],
+) -> str:
+    payload = {
+        "route_name": route_name,
+        "profile_version": profile_version,
+        "sync_count": sync_count,
+        "points": [point.model_dump(mode="json") for point in points],
+    }
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()

--- a/src/navigation/route_mapper.py
+++ b/src/navigation/route_mapper.py
@@ -1,0 +1,343 @@
+from __future__ import annotations
+
+import csv
+import math
+import sqlite3
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_OFF_ROUTE_THRESHOLD_M = 120.0
+
+
+@dataclass(frozen=True)
+class RoutePoint:
+    lat: float
+    lon: float
+    elevation_m: float
+    distance_m: float
+    speed_limit_kmh: float | None = None
+    target_speed_kmh: float | None = None
+    torque_nm: float | None = None
+    power_w: float | None = None
+    stop_type: str | None = None
+    ghi: float | None = None
+    wind_dir: float | None = None
+    wind_speed: float | None = None
+
+
+@dataclass(frozen=True)
+class RouteSegment:
+    route_name: str
+    index: int
+    start: RoutePoint
+    end: RoutePoint
+
+    @property
+    def length_m(self) -> float:
+        return max(self.end.distance_m - self.start.distance_m, haversine_m(self.start.lat, self.start.lon, self.end.lat, self.end.lon))
+
+    @property
+    def grade_percent(self) -> float:
+        if self.length_m <= 0:
+            return 0.0
+        return (self.end.elevation_m - self.start.elevation_m) / self.length_m * 100.0
+
+    @property
+    def speed_limit_kmh(self) -> float | None:
+        return self.start.speed_limit_kmh
+
+    @property
+    def target_speed_kmh(self) -> float | None:
+        return self.start.target_speed_kmh
+
+
+@dataclass(frozen=True)
+class Route:
+    name: str
+    points: list[RoutePoint]
+    segments: list[RouteSegment]
+
+    @property
+    def total_distance_m(self) -> float:
+        return self.points[-1].distance_m if self.points else 0.0
+
+
+@dataclass(frozen=True)
+class RouteMatch:
+    route_name: str
+    segment_index: int
+    along_route_m: float
+    cross_track_m: float
+    distance_to_end_m: float
+    off_route: bool
+    segment: RouteSegment
+
+
+class RouteNotFoundError(ValueError):
+    pass
+
+
+class RouteRepository:
+    """Loads routes and maps positions onto route segments.
+
+    The mapping here is geometric route-position lookup only. It is intentionally
+    separate from future route-update or optimization logic.
+    """
+
+    def __init__(
+        self,
+        project_root: Path | None = None,
+        db_paths: list[Path] | None = None,
+        generated_dir: Path | None = None,
+        limits_dir: Path | None = None,
+    ) -> None:
+        self.project_root = project_root or PROJECT_ROOT
+        self.db_paths = db_paths or [
+            self.project_root / "data.sqlite",
+            self.project_root / "ASC_2024.sqlite",
+        ]
+        self.generated_dir = generated_dir or self.project_root / "data" / "generated"
+        self.limits_dir = limits_dir or self.project_root / "data" / "limits"
+        self._route_cache: dict[str, Route] = {}
+
+    def list_routes(self) -> list[str]:
+        names: set[str] = set()
+        for db_path in self.db_paths:
+            names.update(self._list_db_routes(db_path))
+        if self.generated_dir.exists():
+            for csv_path in self.generated_dir.glob("*.csv"):
+                name = self._csv_route_name(csv_path)
+                if name:
+                    names.add(name)
+        return sorted(names)
+
+    def load_route(self, route_name: str) -> Route:
+        if route_name in self._route_cache:
+            return self._route_cache[route_name]
+
+        points = self._load_points_from_db(route_name)
+        if not points:
+            points = self._load_points_from_csv(route_name)
+        if len(points) < 2:
+            raise RouteNotFoundError(f"Route '{route_name}' was not found or has fewer than two points")
+
+        segments = [RouteSegment(route_name, i, points[i], points[i + 1]) for i in range(len(points) - 1)]
+        route = Route(route_name, points, segments)
+        self._route_cache[route_name] = route
+        return route
+
+    def default_route_name(self) -> str:
+        routes = self.list_routes()
+        if not routes:
+            raise RouteNotFoundError("No routes are available from SQLite or data/generated")
+        return routes[0]
+
+    def map_position(
+        self,
+        route_name: str,
+        lat: float,
+        lon: float,
+        off_route_threshold_m: float = DEFAULT_OFF_ROUTE_THRESHOLD_M,
+    ) -> RouteMatch:
+        """Project a GPS point onto the nearest route segment.
+
+        This returns the current route position used by the API placeholder
+        adapters; it does not optimize or update the route plan.
+        """
+        route = self.load_route(route_name)
+        best: tuple[float, float, RouteSegment] | None = None
+
+        for segment in route.segments:
+            along_m, cross_track_m = project_onto_segment(lat, lon, segment)
+            if best is None or cross_track_m < best[1]:
+                best = (along_m, cross_track_m, segment)
+
+        if best is None:
+            raise RouteNotFoundError(f"Route '{route_name}' has no segments")
+
+        along_m, cross_track_m, segment = best
+        return RouteMatch(
+            route_name=route.name,
+            segment_index=segment.index,
+            along_route_m=along_m,
+            cross_track_m=cross_track_m,
+            distance_to_end_m=max(route.total_distance_m - along_m, 0.0),
+            off_route=cross_track_m > off_route_threshold_m,
+            segment=segment,
+        )
+
+    def _list_db_routes(self, db_path: Path) -> set[str]:
+        if not db_path.exists():
+            return set()
+        try:
+            with sqlite3.connect(db_path) as conn:
+                route_col = self._route_column(conn)
+                if route_col is None:
+                    return set()
+                rows = conn.execute(f"SELECT DISTINCT {route_col} FROM route_data").fetchall()
+                return {str(row[0]) for row in rows if row[0]}
+        except sqlite3.Error:
+            return set()
+
+    def _load_points_from_db(self, route_name: str) -> list[RoutePoint]:
+        for db_path in self.db_paths:
+            if not db_path.exists():
+                continue
+            try:
+                with sqlite3.connect(db_path) as conn:
+                    conn.row_factory = sqlite3.Row
+                    route_col = self._route_column(conn)
+                    if route_col is None:
+                        continue
+                    columns = {row[1] for row in conn.execute("PRAGMA table_info(route_data)").fetchall()}
+                    rows = conn.execute(
+                        f"SELECT * FROM route_data WHERE {route_col} = ? ORDER BY id",
+                        (route_name,),
+                    ).fetchall()
+                    if rows:
+                        return [self._point_from_db_row(row, columns) for row in rows]
+            except sqlite3.Error:
+                continue
+        return []
+
+    def _route_column(self, conn: sqlite3.Connection) -> str | None:
+        columns = {row[1] for row in conn.execute("PRAGMA table_info(route_data)").fetchall()}
+        if "placemark_name" in columns:
+            return "placemark_name"
+        if "segment_id" in columns:
+            return "segment_id"
+        return None
+
+    def _point_from_db_row(self, row: sqlite3.Row, columns: set[str]) -> RoutePoint:
+        return RoutePoint(
+            lat=float(row["lat"]),
+            lon=float(row["lon"]),
+            elevation_m=float(row["elevation"] or 0.0),
+            distance_m=float(row["distance"] or 0.0),
+            speed_limit_kmh=_optional_float(row["speed_limit"] if "speed_limit" in columns else None),
+            target_speed_kmh=_optional_float(row["speed"] if "speed" in columns else None),
+            torque_nm=_optional_float(row["torque"] if "torque" in columns else None),
+            power_w=_optional_float(row["power"] if "power" in columns else None),
+            stop_type=_optional_str(row["stop_type"] if "stop_type" in columns else None),
+            ghi=_optional_float(row["ghi"] if "ghi" in columns else None),
+            wind_dir=_optional_float(row["wind_dir"] if "wind_dir" in columns else None),
+            wind_speed=_optional_float(row["wind_speed"] if "wind_speed" in columns else None),
+        )
+
+    def _load_points_from_csv(self, route_name: str) -> list[RoutePoint]:
+        csv_path = self._csv_path_for_route(route_name)
+        if csv_path is None:
+            return []
+
+        limits = self._load_speed_limits(route_name)
+        points: list[RoutePoint] = []
+        with csv_path.open(newline="") as file:
+            next(file, None)
+            reader = csv.DictReader(file)
+            for row in reader:
+                distance_m = float(row["Distance"])
+                points.append(
+                    RoutePoint(
+                        lat=float(row["Lat"]),
+                        lon=float(row["Lon"]),
+                        elevation_m=float(row.get("Elevation") or 0.0),
+                        distance_m=distance_m,
+                        speed_limit_kmh=self._speed_limit_at(limits, distance_m),
+                        ghi=_optional_float(row.get("Cloud Cover")),
+                        wind_dir=_optional_float(row.get("Wind Direction")),
+                        wind_speed=_optional_float(row.get("Wind Speed")),
+                    )
+                )
+        return points
+
+    def _csv_path_for_route(self, route_name: str) -> Path | None:
+        direct = self.generated_dir / f"{route_name}.csv"
+        if direct.exists():
+            return direct
+        if not self.generated_dir.exists():
+            return None
+        for csv_path in self.generated_dir.glob("*.csv"):
+            if self._csv_route_name(csv_path) == route_name:
+                return csv_path
+        return None
+
+    def _csv_route_name(self, csv_path: Path) -> str | None:
+        try:
+            with csv_path.open(newline="") as file:
+                first_line = file.readline().strip()
+            return first_line or csv_path.stem
+        except OSError:
+            return None
+
+    def _load_speed_limits(self, route_name: str) -> list[tuple[float, float]]:
+        limits_path = self.limits_dir / f"{route_name} Limits.csv"
+        if not limits_path.exists():
+            return []
+        limits: list[tuple[float, float]] = []
+        with limits_path.open(newline="") as file:
+            for row in csv.reader(file):
+                if len(row) >= 3:
+                    limits.append((float(row[1]), float(row[2])))
+        return sorted(limits)
+
+    def _speed_limit_at(self, limits: list[tuple[float, float]], distance_m: float) -> float | None:
+        if not limits:
+            return None
+        current = limits[0][1]
+        for limit_distance_m, speed_limit_kmh in limits:
+            if distance_m < limit_distance_m:
+                break
+            current = speed_limit_kmh
+        return current
+
+
+def project_onto_segment(lat: float, lon: float, segment: RouteSegment) -> tuple[float, float]:
+    px, py = local_xy_m(lat, lon, segment.start.lat, segment.start.lon)
+    ex, ey = local_xy_m(segment.end.lat, segment.end.lon, segment.start.lat, segment.start.lon)
+    length_sq = ex * ex + ey * ey
+    if length_sq <= 0:
+        return segment.start.distance_m, haversine_m(lat, lon, segment.start.lat, segment.start.lon)
+
+    t = max(0.0, min(1.0, (px * ex + py * ey) / length_sq))
+    proj_x = t * ex
+    proj_y = t * ey
+    cross_track_m = math.hypot(px - proj_x, py - proj_y)
+    along_m = segment.start.distance_m + segment.length_m * t
+    return along_m, cross_track_m
+
+
+def local_xy_m(lat: float, lon: float, origin_lat: float, origin_lon: float) -> tuple[float, float]:
+    lat_scale_m = 111_320.0
+    lon_scale_m = lat_scale_m * math.cos(math.radians(origin_lat))
+    return (lon - origin_lon) * lon_scale_m, (lat - origin_lat) * lat_scale_m
+
+
+def haversine_m(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+    radius_m = 6_371_000.0
+    phi1 = math.radians(lat1)
+    phi2 = math.radians(lat2)
+    d_phi = math.radians(lat2 - lat1)
+    d_lambda = math.radians(lon2 - lon1)
+    a = math.sin(d_phi / 2) ** 2 + math.cos(phi1) * math.cos(phi2) * math.sin(d_lambda / 2) ** 2
+    return radius_m * 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a))
+
+
+def _optional_float(value: Any) -> float | None:
+    if value is None or value == "":
+        return None
+    return float(value)
+
+
+def _optional_str(value: Any) -> str | None:
+    if value is None or value == "":
+        return None
+    return str(value)
+
+
+@lru_cache(maxsize=1)
+def get_default_repository() -> RouteRepository:
+    return RouteRepository()

--- a/src/navigation/speed_utils.py
+++ b/src/navigation/speed_utils.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+DEFAULT_RECOMMENDED_SPEED_KMH = 45.0
+
+
+def recommended_speed(speed_limit_kmh: float | None, target_speed_kmh: float | None) -> float:
+    candidates = [value for value in [speed_limit_kmh, target_speed_kmh] if value is not None and value > 0]
+    if not candidates:
+        return DEFAULT_RECOMMENDED_SPEED_KMH
+    return min(candidates)

--- a/tests/test_navigation_mvp.py
+++ b/tests/test_navigation_mvp.py
@@ -1,0 +1,388 @@
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.api.main import create_app
+from src.api.session_store import SessionStore
+from src.navigation.advice_builder import AdviceBuilder
+from src.navigation.profile_builder import (
+    PROFILE_VERSION,
+    SYNC_PROFILE_VERSION,
+    SYNC_SPEED_INCREMENT_KMH,
+    ProfileBundleBuilder,
+)
+from src.navigation.route_mapper import RouteRepository
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+ROUTE_NAME = "A. Independence to Topeka"
+
+
+def test_route_mapper_maps_known_coordinate_to_segment():
+    repository = RouteRepository(project_root=PROJECT_ROOT)
+
+    match = repository.map_position(ROUTE_NAME, 39.092185, -94.417077)
+
+    assert match.route_name == ROUTE_NAME
+    assert match.segment_index == 0
+    assert match.cross_track_m < 1
+    assert not match.off_route
+
+
+def test_route_mapper_flags_far_off_coordinate():
+    repository = RouteRepository(project_root=PROJECT_ROOT)
+
+    match = repository.map_position(ROUTE_NAME, 38.0, -95.0)
+
+    assert match.off_route
+    assert match.cross_track_m > 1_000
+
+
+def test_advice_builder_returns_static_segment_fields():
+    repository = RouteRepository(project_root=PROJECT_ROOT)
+    match = repository.map_position(ROUTE_NAME, 39.092185, -94.417077)
+
+    advice = AdviceBuilder(repository).build(match, current_speed_mps=20)
+
+    assert advice.recommended_speed_kmh > 0
+    assert advice.speed_limit_kmh is not None
+    assert advice.grade_percent is not None
+    assert advice.lookahead
+    assert advice.action in {"hold", "slow_down", "speed_up", "return_to_route"}
+
+
+def test_profile_bundle_contains_route_points_and_advice_fields():
+    repository = RouteRepository(project_root=PROJECT_ROOT)
+    route = repository.load_route(ROUTE_NAME)
+
+    profile = ProfileBundleBuilder(repository).build(ROUTE_NAME)
+    first_point = profile.points[0]
+
+    assert profile.route_name == ROUTE_NAME
+    assert profile.profile_version == PROFILE_VERSION
+    assert profile.profile_hash
+    assert profile.total_distance_m == route.total_distance_m
+    assert len(profile.points) == len(route.points)
+    assert first_point.index == 0
+    assert first_point.along_route_m == first_point.distance_m
+    assert first_point.lat == route.points[0].lat
+    assert first_point.lon == route.points[0].lon
+    assert first_point.recommended_speed_kmh > 0
+    assert first_point.speed_limit_kmh is not None
+    assert first_point.grade_percent is not None
+
+
+def test_api_session_and_telemetry_flow():
+    repository = RouteRepository(project_root=PROJECT_ROOT)
+    app = create_app(repository=repository, store=SessionStore())
+    client = TestClient(app)
+
+    routes = client.get("/api/routes")
+    assert routes.status_code == 200
+    assert ROUTE_NAME in [route["name"] for route in routes.json()["routes"]]
+
+    created = client.post("/api/sessions", json={"route_name": ROUTE_NAME})
+    assert created.status_code == 200
+    session_id = created.json()["session_id"]
+
+    advice = client.post(
+        f"/api/sessions/{session_id}/telemetry",
+        json={"lat": 39.092185, "lon": -94.417077, "speed_mps": 10, "source": "manual"},
+    )
+    assert advice.status_code == 200
+    body = advice.json()
+    assert body["session_id"] == session_id
+    assert body["route_name"] == ROUTE_NAME
+    assert body["recommended_speed_kmh"] > 0
+    assert "lookahead" in body
+
+
+def test_sync_without_client_profile_returns_placeholder_profile_with_future_speed_marker():
+    repository = RouteRepository(project_root=PROJECT_ROOT)
+    route = repository.load_route(ROUTE_NAME)
+    base_profile = ProfileBundleBuilder(repository).build(ROUTE_NAME)
+    app = create_app(repository=repository, store=SessionStore())
+    client = TestClient(app)
+    session_id = client.post("/api/sessions", json={"route_name": ROUTE_NAME}).json()["session_id"]
+    current_point = route.points[0]
+
+    response = client.post(
+        f"/api/sessions/{session_id}/sync",
+        json={
+            "telemetry": {
+                "lat": current_point.lat,
+                "lon": current_point.lon,
+                "speed_mps": 10,
+                "source": "demo",
+            }
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["accepted"] is True
+    assert body["sync_count"] == 1
+    assert body["profile_current"] is False
+    assert body["latest_profile_version"] == SYNC_PROFILE_VERSION
+    assert body["profile"]["route_name"] == ROUTE_NAME
+    assert body["profile"]["profile_version"] == SYNC_PROFILE_VERSION
+    assert body["profile"]["profile_hash"] != base_profile.profile_hash
+    assert len(body["profile"]["points"]) == len(route.points)
+
+    points = body["profile"]["points"]
+    assert points[0]["recommended_speed_kmh"] == pytest.approx(
+        base_profile.points[0].recommended_speed_kmh + SYNC_SPEED_INCREMENT_KMH
+    )
+    assert points[1]["recommended_speed_kmh"] == pytest.approx(
+        base_profile.points[1].recommended_speed_kmh + SYNC_SPEED_INCREMENT_KMH
+    )
+
+    if base_profile.points[0].target_speed_kmh is None:
+        assert points[0]["target_speed_kmh"] is None
+    else:
+        assert points[0]["target_speed_kmh"] == pytest.approx(
+            base_profile.points[0].target_speed_kmh + SYNC_SPEED_INCREMENT_KMH
+        )
+
+    if base_profile.points[1].target_speed_kmh is None:
+        assert points[1]["target_speed_kmh"] is None
+    else:
+        assert points[1]["target_speed_kmh"] == pytest.approx(
+            base_profile.points[1].target_speed_kmh + SYNC_SPEED_INCREMENT_KMH
+        )
+
+
+def test_rolling_sync_second_sync_increments_future_points_cumulatively():
+    repository = RouteRepository(project_root=PROJECT_ROOT)
+    route = repository.load_route(ROUTE_NAME)
+    base_profile = ProfileBundleBuilder(repository).build(ROUTE_NAME)
+    app = create_app(repository=repository, store=SessionStore())
+    client = TestClient(app)
+    session_id = client.post("/api/sessions", json={"route_name": ROUTE_NAME}).json()["session_id"]
+
+    first = client.post(
+        f"/api/sessions/{session_id}/sync",
+        json={
+            "telemetry": {
+                "lat": route.points[0].lat,
+                "lon": route.points[0].lon,
+                "speed_mps": 10,
+                "source": "demo",
+            }
+        },
+    ).json()
+    first_profile = first["profile"]
+    assert first["profile_current"] is False
+
+    second = client.post(
+        f"/api/sessions/{session_id}/sync",
+        json={
+            "telemetry": {
+                "lat": route.points[1].lat,
+                "lon": route.points[1].lon,
+                "speed_mps": 10,
+                "source": "demo",
+            },
+            "client_profile": {
+                "route_name": ROUTE_NAME,
+                "profile_version": SYNC_PROFILE_VERSION,
+                "profile_hash": first_profile["profile_hash"],
+            },
+        },
+    ).json()
+
+    assert second["profile_current"] is False
+    assert second["sync_count"] == 2
+    assert second["profile"]["profile_hash"] != first_profile["profile_hash"]
+    second_points = second["profile"]["points"]
+    assert second_points[0]["recommended_speed_kmh"] == base_profile.points[0].recommended_speed_kmh
+    assert second_points[1]["recommended_speed_kmh"] == pytest.approx(
+        base_profile.points[1].recommended_speed_kmh + 2 * SYNC_SPEED_INCREMENT_KMH
+    )
+    assert second_points[2]["recommended_speed_kmh"] == pytest.approx(
+        base_profile.points[2].recommended_speed_kmh + 2 * SYNC_SPEED_INCREMENT_KMH
+    )
+
+
+def test_four_demo_syncs_at_same_point_increment_speed_cumulatively():
+    repository = RouteRepository(project_root=PROJECT_ROOT)
+    route = repository.load_route(ROUTE_NAME)
+    base_profile = ProfileBundleBuilder(repository).build(ROUTE_NAME)
+    app = create_app(repository=repository, store=SessionStore())
+    client = TestClient(app)
+    session_id = client.post("/api/sessions", json={"route_name": ROUTE_NAME}).json()["session_id"]
+    current_point = route.points[0]
+    expected_speeds = [
+        base_profile.points[0].recommended_speed_kmh + increment * SYNC_SPEED_INCREMENT_KMH
+        for increment in range(1, 5)
+    ]
+
+    for click, expected_speed in enumerate(expected_speeds, start=1):
+        response = client.post(
+            f"/api/sessions/{session_id}/sync",
+            json={
+                "telemetry": {
+                    "lat": current_point.lat,
+                    "lon": current_point.lon,
+                    "speed_mps": 10,
+                    "source": "demo",
+                }
+            },
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["sync_count"] == click
+        assert body["profile"]["points"][0]["recommended_speed_kmh"] == pytest.approx(expected_speed)
+
+
+def test_gps_sync_does_not_increment_sync_count():
+    repository = RouteRepository(project_root=PROJECT_ROOT)
+    route = repository.load_route(ROUTE_NAME)
+    app = create_app(repository=repository, store=SessionStore())
+    client = TestClient(app)
+    session_id = client.post("/api/sessions", json={"route_name": ROUTE_NAME}).json()["session_id"]
+    current_point = route.points[0]
+
+    for _ in range(3):
+        response = client.post(
+            f"/api/sessions/{session_id}/sync",
+            json={
+                "telemetry": {
+                    "lat": current_point.lat,
+                    "lon": current_point.lon,
+                    "speed_mps": 10,
+                    "source": "gps",
+                }
+            },
+        )
+        assert response.status_code == 200
+        assert response.json()["sync_count"] == 0
+
+    demo = client.post(
+        f"/api/sessions/{session_id}/sync",
+        json={
+            "telemetry": {
+                "lat": current_point.lat,
+                "lon": current_point.lon,
+                "speed_mps": 10,
+                "source": "demo",
+            }
+        },
+    )
+    assert demo.status_code == 200
+    assert demo.json()["sync_count"] == 1
+
+
+def test_route_profile_endpoint_returns_full_profile():
+    repository = RouteRepository(project_root=PROJECT_ROOT)
+    route = repository.load_route(ROUTE_NAME)
+    app = create_app(repository=repository, store=SessionStore())
+    client = TestClient(app)
+
+    response = client.get(f"/api/routes/{ROUTE_NAME}/profile")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["route_name"] == ROUTE_NAME
+    assert body["profile_version"] == PROFILE_VERSION
+    assert len(body["points"]) == len(route.points)
+
+
+def test_sync_always_returns_updated_profile_even_when_client_reports_current_hash():
+    repository = RouteRepository(project_root=PROJECT_ROOT)
+    route = repository.load_route(ROUTE_NAME)
+    app = create_app(repository=repository, store=SessionStore())
+    client = TestClient(app)
+    session_id = client.post("/api/sessions", json={"route_name": ROUTE_NAME}).json()["session_id"]
+
+    first = client.post(
+        f"/api/sessions/{session_id}/sync",
+        json={
+            "telemetry": {
+                "lat": route.points[0].lat,
+                "lon": route.points[0].lon,
+                "speed_mps": 10,
+                "source": "demo",
+            }
+        },
+    ).json()
+    first_profile = first["profile"]
+
+    repeat = client.post(
+        f"/api/sessions/{session_id}/sync",
+        json={
+            "telemetry": {
+                "lat": route.points[0].lat,
+                "lon": route.points[0].lon,
+                "speed_mps": 10,
+                "source": "demo",
+            },
+            "client_profile": {
+                "route_name": ROUTE_NAME,
+                "profile_version": SYNC_PROFILE_VERSION,
+                "profile_hash": first_profile["profile_hash"],
+            },
+        },
+    ).json()
+
+    assert repeat["profile_current"] is False
+    assert repeat["profile"] is not None
+    assert repeat["profile"]["profile_hash"] != first_profile["profile_hash"]
+    repeat_points = repeat["profile"]["points"]
+    assert repeat_points[0]["recommended_speed_kmh"] == pytest.approx(
+        first["profile"]["points"][0]["recommended_speed_kmh"] + SYNC_SPEED_INCREMENT_KMH
+    )
+    assert repeat_points[1]["recommended_speed_kmh"] == pytest.approx(
+        first["profile"]["points"][1]["recommended_speed_kmh"] + SYNC_SPEED_INCREMENT_KMH
+    )
+
+
+def test_sync_accepts_telemetry_and_returns_advice():
+    repository = RouteRepository(project_root=PROJECT_ROOT)
+    route = repository.load_route(ROUTE_NAME)
+    app = create_app(repository=repository, store=SessionStore())
+    client = TestClient(app)
+    session_id = client.post("/api/sessions", json={"route_name": ROUTE_NAME}).json()["session_id"]
+
+    response = client.post(
+        f"/api/sessions/{session_id}/sync",
+        json={
+            "telemetry": {
+                "lat": route.points[1].lat,
+                "lon": route.points[1].lon,
+                "speed_mps": 8,
+                "source": "demo",
+            },
+            "client_profile": {"profile_version": SYNC_PROFILE_VERSION},
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["accepted"] is True
+    assert body["profile_current"] is False
+    assert body["profile"] is not None
+    assert body["advice"]["session_id"] == session_id
+    assert body["advice"]["route_name"] == ROUTE_NAME
+    assert body["advice"]["recommended_speed_kmh"] > 0
+    assert body["advice"]["lookahead"]
+
+
+def test_api_replay_progresses_along_route():
+    repository = RouteRepository(project_root=PROJECT_ROOT)
+    route = repository.load_route(ROUTE_NAME)
+    app = create_app(repository=repository, store=SessionStore())
+    client = TestClient(app)
+    session_id = client.post("/api/sessions", json={"route_name": ROUTE_NAME}).json()["session_id"]
+
+    along_values = []
+    for point in route.points[:4]:
+        response = client.post(
+            f"/api/sessions/{session_id}/telemetry",
+            json={"lat": point.lat, "lon": point.lon, "speed_mps": 8, "source": "demo"},
+        )
+        assert response.status_code == 200
+        along_values.append(response.json()["along_route_m"])
+
+    assert along_values == sorted(along_values)


### PR DESCRIPTION
﻿## Summary

This PR adds a FastAPI navigation MVP on RaceStrategies so the native Android phone client (`solarcar_phone_app`, sibling repo) can create sessions, sync GPS telemetry, and download route profile bundles for offline target-speed lookup.

Product model:

- Backend/computer owns route/profile generation and future reoptimization.
- Phone stores the full profile locally and maps GPS to target speed from cache when offline.
- When online, phone calls `/sync` for advice and refreshed profiles; connection loss falls back to the last cached profile.

**This repo (RaceStrategies):**

- FastAPI app: health, routes, profile download, sessions, telemetry, and `/api/sessions/{id}/sync`.
- Navigation layer: route mapping from KML/route data, advice builder, static/placeholder profile bundles.
- Rolling sync **placeholder** (not real reoptimization): demo syncs bump `sync_count` and raise recommended/target speeds from the current position forward; live GPS syncs reuse the count without incrementing; `profile_current=false` so the phone always accepts MVP test updates.
- In-memory session store, CORS for dev, readme + dependencies for running uvicorn.
- Removed Capacitor/PWA prototype direction from this repo; phone UI lives only in `solarcar_phone_app`.
- Minor kinematics helpers (`Speed.rps`, `Coordinate` repr) used by navigation/tests.

**Phone client (separate repo — not in this commit):**

- [`solarcar_phone_app`](https://github.com/McMasterSolarCarProject/solarcar_phone_app) integrates with this API, caches profiles, offline lookup, and driver-facing status fields. See [phone app PR #1](https://github.com/McMasterSolarCarProject/solarcar_phone_app/pull/1) for the navigation MVP client work.

## Not included yet

- Real rolling reoptimization from position/velocity/SOC.
- SOC/microcontroller fields in sync contract.
- Durable session persistence.
- Production race-day UI polish.

## Setup

### Backend (this repo)

1. Create and activate a Python venv, then install dependencies:

   ```bash
   python -m venv .venv
   .venv\Scripts\activate          # Windows
   pip install -r requirements.txt
   ```

2. Start the navigation API (keep this terminal open while testing):

   ```bash
   python -m uvicorn src.api.main:app --host 0.0.0.0 --port 8000
   ```

   Stop with **Ctrl+C** when running offline-fallback tests.

3. **Windows firewall (LAN / physical phone):** allow inbound TCP **8000** on the host running uvicorn (Private network profile is usually enough). Find the host LAN IP with `ipconfig` (e.g. `192.168.1.42`).

### Phone client (sibling repo)

- Clone/build [`solarcar_phone_app`](https://github.com/McMasterSolarCarProject/solarcar_phone_app) per [PR #1](https://github.com/McMasterSolarCarProject/solarcar_phone_app/pull/1).

**Physical phone on the same Wi‑Fi as the backend host** — rebuild with the host LAN IP:

```powershell
./gradlew assembleDebug -PraceStrategiesBaseUrl=http://<LAN-IP>:8000/
```

**Emulator / BlueStacks** — use the Android emulator loopback or the host LAN IP:

- Android emulator: `http://10.0.2.2:8000/`
- BlueStacks or emulator on same PC: `http://10.0.2.2:8000/` or `http://<LAN-IP>:8000/`

## Testing

### Automated

```bash
pytest tests/test_navigation_mvp.py
```

Covers route mapping, advice, profile bundles, session/telemetry flow, sync placeholder, rolling demo sync, and GPS sync-count behavior.

### API smoke (backend running)

```bash
curl http://localhost:8000/api/health

curl -X POST http://localhost:8000/api/sessions ^
  -H "Content-Type: application/json" ^
  -d "{\"route_name\": \"A. Independence to Topeka\"}"

curl -X POST http://localhost:8000/api/sessions/<SESSION_ID>/sync ^
  -H "Content-Type: application/json" ^
  -d "{\"telemetry\": {\"lat\": 39.092185, \"lon\": -94.417077, \"speed_mps\": 10, \"source\": \"demo\"}}"
```

(On bash/macOS, use `\` line continuations and single-quoted JSON.)

### Manual — phone app

- [ ] **Start logging** — session created, telemetry/advice updates.
- [ ] **Test Route Replay** — demo positions advance along the route.
- [ ] **Next** — each tap triggers a demo sync; recommended speeds on current-and-future profile points bump (e.g. **32.19 → 32.20 → 32.21** km/h per sync with the MVP +0.01 km/h placeholder increment).
- [ ] **Rolling sync** — repeated syncs at the same point accumulate the bump on future points.

### Manual — offline fallback

- [ ] With a cached profile on the phone, **stop the backend** (Ctrl+C in the uvicorn terminal).
- [ ] Confirm guidance continues from the last cached profile (no crash; status reflects offline).

### Manual — BlueStacks

- [ ] Use BlueStacks **HD-Adb.exe** (not the standalone Android SDK `adb`) when sideloading or debugging.
- [ ] Point base URL at `http://10.0.2.2:8000/` (or host LAN IP); run create session → sync → offline steps above.

## Future: any-network access (Option B — not in this PR)

Long-term plan: expose a home/race-day PC over the public internet so the phone works off-LAN (cellular, other Wi‑Fi):

1. **DDNS** on the home router (stable hostname → public IP).
2. **Port forward** (e.g. external 443 → host running RaceStrategies API).
3. **HTTPS** termination (reverse proxy or uvicorn TLS) — do not ship plain HTTP over the internet.
4. **In-app backend URL** in `solarcar_phone_app` (build-time or settings) pointing at `https://<your-hostname>/`.

This PR and the current phone MVP target **same-LAN / emulator** only; Option B is a follow-up across infra + phone app configuration.
